### PR TITLE
Improved compatibility with paper plugin loader

### DIFF
--- a/src/main/java/io/github/monun/autoreloader/plugin/AutoReloaderPlugin.java
+++ b/src/main/java/io/github/monun/autoreloader/plugin/AutoReloaderPlugin.java
@@ -6,13 +6,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Server;
 import org.bukkit.configuration.Configuration;
-import org.bukkit.plugin.SimplePluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Objects;
 
 public class AutoReloaderPlugin extends JavaPlugin {
@@ -25,9 +23,7 @@ public class AutoReloaderPlugin extends JavaPlugin {
         Server server = getServer();
 
         try {
-            Field field = SimplePluginManager.class.getDeclaredField("updateDirectory");
-            field.setAccessible(true);
-            File updateDirectory = (File) field.get(server.getPluginManager());
+            File updateDirectory = server.getUpdateFolderFile();
             updateDirectory.mkdirs();
             reloadFile = new File(updateDirectory, "RELOAD");
 


### PR DESCRIPTION
#3 해결

`getUpdateFolderFile`는 2011년부터 있었던 Bukkit 메서드이기에 리플렉션을 사용하지 않아도 될 것 같습니다.

_(리플렉션을 사용하는 특별한 이유가 있다면)_
새 플러그인 로더가 적용된 최신 버전의 Paper는 `SimplePluginManager` 클래스가 아닌 `PluginInitializerManager` 클래스에서 업데이트 폴더가 정의되는데, 업데이트 폴더가 생성되지 않았을 땐 `updateDirectory` 필드를 null로 채워버리기에 `getUpdateFolderFile`를 사용하는 것이 최선이라고 생각합니다.